### PR TITLE
Update PrettyCoffee's coffee startpage link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - [Heimdall](https://github.com/linuxserver/Heimdall) - Server-service based application orientated dashboard.
 - [Organizr](https://github.com/causefx/Organizr) - Organizr allows you to setup "Tabs" that will be loaded all in one webpage.
 - [pomme-page](https://github.com/kikiklang/pomme-page) - Pretty cool startpage with colorful tiles.
-- [PrettyCoffe's Startpage](https://github.com/PrettyCoffee/startpage) - Super smooth and stylish startpage. Tuned aesthetic.
+- [PrettyCoffe's Startpage](https://github.com/PrettyCoffee/fluidity) - Super smooth and stylish startpage. Tuned aesthetic.
 - [root](https://github.com/imreyesjorge/root-startpage) - Root is a start-page aimed to simplicity and elegance.
 
 ### Static


### PR DESCRIPTION
Updated according to the notice on the old repo.
![image](https://user-images.githubusercontent.com/25097841/115821541-9b849c00-a420-11eb-8dd9-e6e16080dc01.png)
