### PR TITLE
Add Homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 - [fluidity](https://github.com/PrettyCoffee/fluidity) - Super smooth and stylish startpage. Tuned aesthetic.
 - [Galax's Startpage](https://github.com/Galax028/startpage) - A minimal startpage made in React.js with customizable bookmarks.
 - [Heimdall](https://github.com/linuxserver/Heimdall) - Server-service based application orientated dashboard.
+- [Homepage](https://github.com/gethomepage/homepage) - A modern, static, self-hosted dashboard offering fast performance, full proxy security, high customization, 100+ service integrations, multiple language translations, and easy configuration via YAML or docker labels.
 - [Jump](https://github.com/daledavies/jump) - Self-hosted startpage designed to be simple, stylish, fast and secure.
 - [Minimalist-Startpage](https://github.com/ropoko/Startpage) - Minimalist startpage with light/dark theme, also useful to change between searchers.
 - [Modular Grid Page](https://github.com/timothypholmes/startup-page) - Modular Grid Start Page for your Browser.


### PR DESCRIPTION
Hey @jnmcfly - I suggest we add Homepage (https://gethomepage.dev/) as it is a great self-hosted dashboard, I use it as my start page.